### PR TITLE
Set @run-at document-idle

### DIFF
--- a/co_editing_mode.user.js
+++ b/co_editing_mode.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Qiita:Team Extension (Co-editing mode)
 // @namespace    https://github.com/yasslab/
-// @version      0.3
+// @version      0.4
 // @description  Automatically select co-editing mode
 // @author       nalabjp
 // @match        https://yasslab.qiita.com/drafts/*

--- a/co_editing_mode.user.js
+++ b/co_editing_mode.user.js
@@ -6,6 +6,7 @@
 // @author       nalabjp
 // @match        https://yasslab.qiita.com/drafts/*
 // @grant        none
+// @run-at       document-idle
 // ==/UserScript==
 
 

--- a/default_group.user.js
+++ b/default_group.user.js
@@ -6,6 +6,7 @@
 // @author       nalabjp
 // @match        https://yasslab.qiita.com/drafts/*
 // @grant        none
+// @run-at       document-idle
 // ==/UserScript==
 
 (function() {

--- a/default_group.user.js
+++ b/default_group.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Qiita:Team Extension (Default group)
 // @namespace    https://github.com/yasslab/
-// @version      0.1.3
+// @version      0.1.4
 // @description  Automatically select a group to publish
 // @author       nalabjp
 // @match        https://yasslab.qiita.com/drafts/*


### PR DESCRIPTION
デフォルトの挙動がdocument-endでViolentmonkeyだとうまく動かなかった

> document-end is the standard behavior that Greasemonkey has always
> had (see DOMContentLoaded). This is the default if no value is
> provided. The script will run after the main page is loaded, but before
> other resources (images, style sheets, etc.) have loaded.

document-idleだと動いたのでdocument-idleに変更した

> document-idle is new as of version 3.6. The script will run after the
> page and all resources (images, style sheets, etc.) are loaded and page
> scripts have run.
https://wiki.greasespot.net/Metadata_Block#.40run-at